### PR TITLE
Do not download Composer and Box upon every build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,9 +29,7 @@
 
     <target name="composer">
         <echo message="Installing API dependencies" />
-        <exec escape="false" dir="contao-manager-${version}" command="curl -LSs https://getcomposer.org/installer | php" />
-        <exec executable="php" dir="contao-manager-${version}" checkreturn="true">
-            <arg value="composer.phar" />
+        <exec executable="composer" dir="contao-manager-${version}" checkreturn="true">
             <arg value="install" />
             <arg value="--prefer-dist" />
             <arg value="--no-dev" />

--- a/build.xml
+++ b/build.xml
@@ -72,9 +72,7 @@
 
     <target name="box">
         <echo message="Creating the .phar file" />
-        <exec escape="false" dir="contao-manager-${version}" command="curl -LSs https://box-project.github.io/box2/installer.php | php" />
-        <exec executable="php" dir="contao-manager-${version}" checkreturn="true">
-            <arg value="box.phar" />
+        <exec executable="box" dir="contao-manager-${version}" checkreturn="true">
             <arg value="build" />
         </exec>
     </target>


### PR DESCRIPTION
Just like `git` and `npm`, the `composer` and `box` binaries should be installed locally in `/usr/local/bin/` instead of downloaded upon every build.