### PR TITLE
add all-inkl.com to providers.yml

### DIFF
--- a/api/Resources/config/providers.yml
+++ b/api/Resources/config/providers.yml
@@ -1,5 +1,5 @@
-all-inkl.com:
-    name: ALL-INKL.COM
+kasserver.com:
+    name: ALL-INKL.COM - Neue Medien Münnich
     website: www.all-inkl.com
     last_update: 2017-06-17
     issues: []

--- a/api/Resources/config/providers.yml
+++ b/api/Resources/config/providers.yml
@@ -1,3 +1,12 @@
+all-inkl.com:
+    name: ALL-INKL.COM
+    website: www.all-inkl.com
+    last_update: 2017-06-17
+    issues: []
+    php:
+        - /usr/bin/php{major}{minor}
+        - /usr/bin/php
+
 cyon.ch:
     name: cyon GmbH
     website: www.cyon.ch


### PR DESCRIPTION
I added the php binaries for all-inkl.com. They provide the following binariesin /usr/bin:
php (same as php56), php53, php54, php55, php56, php70, php71