### PR TITLE
update .gitattributes to force lf line endings in *.js and *.vue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.vue text eol=lf


### PR DESCRIPTION
When developing on Windows, the linter is going crazy about line endings, if core.autocrlf is on. The settings in .gitattributes force unix-style line endings on files that are subject to linting. 