### PR TITLE
Add ETES to the list of known hosting providers

### DIFF
--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -21,11 +21,13 @@ domains:
     uberspace.de: uberspace
     vhost.io: hostingwerk
     your-server.de: hetzner
+    etes.de: etes
 
 networks:
     AS15817: mittwald
     AS29097: hostpoint
     AS47302: cyon
+    AS205890: etes
 
 configs:
     1und1:
@@ -78,6 +80,14 @@ configs:
         issues: []
         php:
             /usr/local/bin/edis-php-cli-{major}{minor}-stable-openssl: []
+
+    etes:
+        name: ETES GmbH
+        website: www.etes.de
+        last_update: 2017-12-15
+        issues: []
+        php:
+            /bin/php{major}{minor}: []
 
     exigo:
         name: exigo AG

--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -27,7 +27,6 @@ networks:
     AS15817: mittwald
     AS29097: hostpoint
     AS47302: cyon
-    AS205890: etes
 
 configs:
     1und1:


### PR DESCRIPTION
I suspect the AS number is for automatic lookup of the matching provider? If so, I added our own AS.