### PR TITLE
update PHP path for WebGo shared hosting

### DIFF
--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -279,7 +279,7 @@ configs:
         last_update: 2017-12-21
         issues: []
         php:
-            /usr/bin/php{major}{minor}: []
+            /usr/bin/php{major}.{minor}: []
             /opt/php-{major}.{minor}/bin/php: []
             /usr/bin/php: []
 


### PR DESCRIPTION
`/usr/bin/php71` is now a symlink to `/usr/bin/php7.1`. This symlink won't exist anymore in newer shared hosting accounts.