### PR TITLE
Switch to composer remote filesystem

### DIFF
--- a/api/TaskOperation/Composer/CreateProjectOperation.php
+++ b/api/TaskOperation/Composer/CreateProjectOperation.php
@@ -15,6 +15,7 @@ use Composer\IO\NullIO;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\RepositoryFactory;
+use Composer\Util\RemoteFilesystem;
 use Contao\ManagerApi\Composer\Environment;
 use Contao\ManagerApi\I18n\Translator;
 use Contao\ManagerApi\Task\TaskConfig;
@@ -111,11 +112,11 @@ class CreateProjectOperation extends AbstractInlineOperation
             throw new \RuntimeException('No valid package to install');
         }
 
-        // TODO use composer remote filesystem
+        $remoteFilesystem = new RemoteFilesystem(new NullIO());
 
         $this->filesystem->dumpFile(
             $this->environment->getJsonFile(),
-            file_get_contents('https://raw.githubusercontent.com/contao/managed-edition/'.$package->getDistReference().'/composer.json')
+            $remoteFilesystem->getContents('raw.githubusercontent.com', 'https://raw.githubusercontent.com/contao/managed-edition/'.$package->getDistReference().'/composer.json')
         );
 
         return true;


### PR DESCRIPTION
Der PR ersetzt `file_get_contents` durch `Composer\Util\RemoteFilesystem::getContents`. Dadurch werden auch die Proxy-Einstellungen (genauer gesagt `$_SERVER['CGI_HTTP_PROXY']`) berücksichtigt, siehe #310, und Contao kann hinter dem Proxy installiert werden.