### PR TITLE
add .protect to allowed root files, sort list

### DIFF
--- a/api/Controller/Server/ContaoController.php
+++ b/api/Controller/Server/ContaoController.php
@@ -97,18 +97,19 @@ class ContaoController extends Controller
             [
                 '.',
                 '..',
-                '.git',
-                '.idea',
-                'cgi-bin',
-                'contao-manager',
-                'web',
-                '.bash_profile',
                 '.bash_logout',
+                '.bash_profile',
                 '.bashrc',
                 '.DS_Store',
                 '.ftpquota',
+                '.git',
                 '.htaccess',
+                '.idea',
+                '.protect',
+                'cgi-bin',
+                'contao-manager',
                 'user.ini',
+                'web',
             ]
         );
 


### PR DESCRIPTION
`.protect` is a undeletable directory present in the document root of CloudBlue webhosting, allow it to be present. Also, I alphabetically sorted this list.