### PR TITLE
Remove target="_blank" from the back end links

### DIFF
--- a/src/components/fragments/Navigation.vue
+++ b/src/components/fragments/Navigation.vue
@@ -8,7 +8,7 @@
                 <a tabindex="0" aria-haspopup="true" onclick="">{{ 'ui.navigation.tools' | translate }}</a>
                 <ul class="navigation__group navigation__group--sub">
                     <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao">{{ 'ui.navigation.backend' | translate }}</a></li>
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode" target="_blank"><a href="/app_dev.php/">{{ 'ui.navigation.debug' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode"><a href="/app_dev.php/" target="_blank">{{ 'ui.navigation.debug' | translate }}</a></li>
                     <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao/install" target="_blank">{{ 'ui.navigation.installTool' | translate }}</a></li>
                     <li class="navigation__item navigation__item--sub"><a href="#" @click.prevent="phpinfo">{{ 'ui.navigation.phpinfo' | translate }}</a></li>
                 </ul>

--- a/src/components/fragments/Navigation.vue
+++ b/src/components/fragments/Navigation.vue
@@ -7,9 +7,9 @@
             <li class="navigation__item navigation__item--main">
                 <a tabindex="0" aria-haspopup="true" onclick="">{{ 'ui.navigation.tools' | translate }}</a>
                 <ul class="navigation__group navigation__group--sub">
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao" target="_blank">{{ 'ui.navigation.backend' | translate }}</a></li>
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode"><a href="/app_dev.php/" target="_blank">{{ 'ui.navigation.debug' | translate }}</a></li>
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao/install" target="_blank">{{ 'ui.navigation.installTool' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao">{{ 'ui.navigation.backend' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode"><a href="/app_dev.php/">{{ 'ui.navigation.debug' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao/install">{{ 'ui.navigation.installTool' | translate }}</a></li>
                     <li class="navigation__item navigation__item--sub"><a href="#" @click.prevent="phpinfo">{{ 'ui.navigation.phpinfo' | translate }}</a></li>
                 </ul>
             </li>

--- a/src/components/fragments/Navigation.vue
+++ b/src/components/fragments/Navigation.vue
@@ -8,8 +8,8 @@
                 <a tabindex="0" aria-haspopup="true" onclick="">{{ 'ui.navigation.tools' | translate }}</a>
                 <ul class="navigation__group navigation__group--sub">
                     <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao">{{ 'ui.navigation.backend' | translate }}</a></li>
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode"><a href="/app_dev.php/">{{ 'ui.navigation.debug' | translate }}</a></li>
-                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao/install">{{ 'ui.navigation.installTool' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode && showDebugMode" target="_blank"><a href="/app_dev.php/">{{ 'ui.navigation.debug' | translate }}</a></li>
+                    <li class="navigation__item navigation__item--sub" v-if="!safeMode"><a href="/contao/install" target="_blank">{{ 'ui.navigation.installTool' | translate }}</a></li>
                     <li class="navigation__item navigation__item--sub"><a href="#" @click.prevent="phpinfo">{{ 'ui.navigation.phpinfo' | translate }}</a></li>
                 </ul>
             </li>


### PR DESCRIPTION
As discussed [in the last call](https://github.com/contao/contao/issues/245#issuecomment-449027444), we want the links from the back end to the Contao Manager and from the Contao Manager to the back end to open in the same window. People can still open links without `target="_blank"` in new tabs if they want, but they cannot open links with `target="_blank"` in the same tab if they want.