### PR TITLE
Center "Search by algolia" link itself instead of the image inside

### DIFF
--- a/src/components/routes/PackageSearch.vue
+++ b/src/components/routes/PackageSearch.vue
@@ -222,9 +222,8 @@
         }
 
         &__algolia {
-            display: block;
-            margin: 50px 0 0;
-            text-align: center;
+            display: table;
+            margin: 50px auto 0;
         }
     }
 </style>


### PR DESCRIPTION
This reduces the area covered by the link to just the image instead of the entire line including the empty space to the sides of the image.