### PR TITLE
Support deployer environment when detecting project dir.

### DIFF
--- a/api/ApiKernel.php
+++ b/api/ApiKernel.php
@@ -223,7 +223,13 @@ CODE
             $current = dirname($phar);
 
             if ('web' === basename($current)) {
-                return dirname($current);
+                $projectDir = dirname($current);
+                if ('shared' === basename($projectDir) && is_file($projectDir.'/../.dep/releases')) {
+                    // Support deployer environment
+                    $projectDir = dirname($projectDir).'/current';
+                }
+
+                return $projectDir;
             }
 
             return $current;


### PR DESCRIPTION
So I just deployed a project with [Deployer](https://github.com/deployphp/deployer), and I wanted to install the Contao Manager after that. 
The `contao-manager.phar.php` and the `contao-manager/` directory both are symlinked (`"shared_dirs"`).

When I started the Contao Manager, it complained about unknown directories first; then I realized the CM is not able to determine the correct Contao version, which is because the `shared` directory is detected as the `projectDir`. To fix this, I rewrote the `projectDir` to the `current` folder.

If you wonder, why I want to use the Contao Manager: The Contao Manager is needed to communicate with [trakked.io](https://www.trakked.io/de/).