### PR TITLE
Add parameter to ETES hosting providers configuration

### DIFF
--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -128,7 +128,7 @@ configs:
         name: ETES GmbH
         website: www.etes.de
         php:
-            /bin/php{major}{minor}: []
+            /bin/php{major}{minor}: ['-d', 'memory_limit=-1']
 
     exigo:
         name: exigo AG


### PR DESCRIPTION
Add the parameter memory_limit=-1 to ETES hosting providers configuration.