### PR TITLE
Handle connection errors when trying to fetch update info

### DIFF
--- a/api/Controller/Server/SelfUpdateController.php
+++ b/api/Controller/Server/SelfUpdateController.php
@@ -36,9 +36,12 @@ class SelfUpdateController
             );
         }
 
+        $error = null;
+
         try {
             $latestVersion = $updater->getNewVersion();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            $error = $e->getMessage();
             $latestVersion = $updater->getOldVersion();
         }
 
@@ -48,6 +51,7 @@ class SelfUpdateController
                 'latest_version' => $latestVersion,
                 'channel' => $updater->getChannel(),
                 'supported' => $updater->supportsUpdate(),
+                'error' => $error,
             ]
         );
     }

--- a/api/Exception/RequestException.php
+++ b/api/Exception/RequestException.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao Manager.
+ *
+ * (c) Contao Association
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerApi\Exception;
+
+use Throwable;
+
+class RequestException extends \RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    public function __construct(string $url, int $statusCode, Throwable $previous = null)
+    {
+        $message = "HTTP request to $url failed with status code $statusCode";
+
+        if ($previous) {
+            $message .= ' ('.$previous->getMessage().')';
+        }
+
+        parent::__construct(
+            $message,
+            $previous ? $previous->getCode() : 0,
+            $previous
+        );
+
+        $this->url = $url;
+        $this->statusCode = $statusCode;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/api/System/IpInfo.php
+++ b/api/System/IpInfo.php
@@ -48,7 +48,7 @@ class IpInfo
         }
 
         if (empty($template['ip'])) {
-            $template['ip'] = (string) $this->request->get('https://api.ipify.org', $status, true);
+            $template['ip'] = $this->request->get('https://api.ipify.org', $status, true);
         }
 
         if (empty($template['ip'])) {

--- a/api/System/SelfUpdate.php
+++ b/api/System/SelfUpdate.php
@@ -243,7 +243,7 @@ class SelfUpdate
 
         $result = $this->request->getStream($url);
 
-        if (false === $result) {
+        if (null === $result) {
             throw new \RuntimeException(sprintf('Request to URL failed: %s', $url));
         }
 

--- a/src/components/boot/SelfUpdate.vue
+++ b/src/components/boot/SelfUpdate.vue
@@ -40,6 +40,11 @@
                 }
 
                 if (result.error) {
+                    if (result.channel === 'dev') {
+                        this.emitState('warning', result.error);
+                        return;
+                    }
+
                     try {
                         const latest = await this.$store.dispatch('server/self-update/latest');
 

--- a/src/components/fragments/BootCheck.vue
+++ b/src/components/fragments/BootCheck.vue
@@ -8,7 +8,7 @@
 
         <div class="boot-check__label">
             <h2 class="boot-check__title">{{ title }}</h2>
-            <p class="boot-check__description">{{ description }}</p>
+            <p class="boot-check__description" v-html="description">{{ description }}</p>
             <p class="boot-check__detail" v-if="detail">{{ detail }}</p>
         </div>
         <div class="boot-check__action">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -59,6 +59,8 @@
     "ui.server.prerequisite": "Check cancelled due to a missing prerequisite.",
     "ui.server.selfUpdate.title": "Updates of Contao Manager",
     "ui.server.selfUpdate.update": "A new Contao Manager version {latest} is available.",
+    "ui.server.selfUpdate.manualUpdate": "A new Contao Manager version {latest} is available. Your server does not support automatic updates, please download the new version from {download}.",
+    "ui.server.selfUpdate.manualUpdateUrl": "https://contao.org/en/download.html",
     "ui.server.selfUpdate.latest": "You are using the latest version {current}.",
     "ui.server.selfUpdate.dev": "Development builds do not support automatic updates.",
     "ui.server.selfUpdate.unsupported": "A new version is available but it does not support your PHP version.",

--- a/src/store/server/selfUpdate.js
+++ b/src/store/server/selfUpdate.js
@@ -33,6 +33,7 @@ export default {
                             latest_version: null,
                             channel: 'dev',
                             supported: false,
+                            error: null,
                         };
                     }
 
@@ -43,6 +44,12 @@ export default {
 
                 return result;
             });
+        },
+
+        async latest() {
+            const response = await Vue.http.get('https://download.contao.org/contao-manager/stable/contao-manager.version');
+
+            return response.body.version;
         },
     },
 };


### PR DESCRIPTION
If the Contao Manager cannot connect to the update server, it will now display a warning and connection error message in the boot screen.

Additionally, we can try to fetch the latest version locally (in the browser) and display an requirement to update manually.

fixes #481

_waiting for download.contao.org to allow CORS requests_ @leofeyer 