### PR TITLE
PHP-Binary Pfade für Timme Hosting aktualisiert. Closes #538

### DIFF
--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -330,6 +330,7 @@ configs:
         website: timmehosting.de
         php:
             /opt/php-{major}.{minor}.{release}/bin/php: []
+            /opt/php-{major}.{minor}/bin/php: []
 
     tobiasbauer:
         name: Tobias Bauer


### PR DESCRIPTION
Wie in #538 beschreiben gibt es zusätzliche Pfade unter denen PHP-Binaries gefunden werden können. 

Dieses PR beinhaltet die nötige Anpassung. 