### PR TITLE
Disable memory limit for cyon webhosting

### DIFF
--- a/api/Resources/config/servers.yml
+++ b/api/Resources/config/servers.yml
@@ -97,7 +97,7 @@ configs:
         name: cyon GmbH
         website: www.cyon.ch
         php:
-            /opt/alt/php{major}{minor}/usr/bin/php: []
+            /opt/alt/php{major}{minor}/usr/bin/php: ['-d', 'memory_limit=-1']
 
     dmservices:
         name: DM Solutions e.K.


### PR DESCRIPTION
This PR disables the memory limit on cyon webhostings. Otherwise a default limit of 2 GB is applied, which might not be sufficient.