### PR TITLE
Update webpack loader config to work with windows directory separators as well

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -30,18 +30,15 @@ module.exports = {
                         test: /(site\.webmanifest|browserconfig\.xml)$/,
                         use: [
                             {
-                                loader: "file-loader",
-                                options: {
-                                    name: "icons/[name].[hash:8].[ext]",
-                                },
+                                loader: "file-loader"
                             },
                             {
-                                loader: "app-manifest-loader",
-                            },
+                                loader: "app-manifest-loader"
+                            }
                         ]
                     },
                     {
-                        test: /icons\/[^/]+.(png|jpe?g|gif|webp|svg|ico)(\?.*)?$/,
+                        test: /icons[\\/][^\\/]+\.(png|jpe?g|gif|webp|svg|ico)(\?.*)?$/,
                         use: [
                             {
                                 loader: "file-loader",
@@ -62,7 +59,7 @@ module.exports = {
     chainWebpack: config => {
         config.module
             .rule('images')
-            .test(/images\/[^/]+.(png|jpe?g|gif|webp)(\?.*)?$/)
+            .test(/images[\\/][^\\/]+\.(png|jpe?g|gif|webp)(\?.*)?$/)
             .use('image-webpack-loader')
             .loader('image-webpack-loader')
         ;


### PR DESCRIPTION
Webpack fails due to loader only checking for forward slashes in in tests. These fail on Windows systems, hence images could not be loaded. 

Also, the options in the webmanifest and browserconfig related file loader are uneccesary and seem to be there due to copy pasting (see https://www.npmjs.com/package/app-manifest-loader).