### PR TITLE
Use is_readable check

### DIFF
--- a/api/Process/AbstractProcess.php
+++ b/api/Process/AbstractProcess.php
@@ -50,8 +50,12 @@ abstract class AbstractProcess
         // Make sure new process files are found (see https://github.com/contao/contao-manager/issues/438)
         clearstatcache();
 
+        if (!is_file($filename)) {
+            throw new \InvalidArgumentException(sprintf('Config file "%s" does not exist.', $filename));
+        }
+
         if (!is_readable($filename)) {
-            throw new \InvalidArgumentException(sprintf('Config file "%s" does not exist or is not readable.', $filename));
+            throw new \RuntimeException(sprintf('Config file "%s" is not readable.', $filename));
         }
 
         $content = file_get_contents($filename);

--- a/api/Process/AbstractProcess.php
+++ b/api/Process/AbstractProcess.php
@@ -50,8 +50,8 @@ abstract class AbstractProcess
         // Make sure new process files are found (see https://github.com/contao/contao-manager/issues/438)
         clearstatcache();
 
-        if (!is_file($filename)) {
-            throw new \InvalidArgumentException(sprintf('Config file "%s" does not exist.', $filename));
+        if (!is_readable($filename)) {
+            throw new \InvalidArgumentException(sprintf('Config file "%s" does not exist or is not readable.', $filename));
         }
 
         $content = file_get_contents($filename);


### PR DESCRIPTION
If a config file is [not readable for whatever reason](https://community.contao.org/de/showthread.php?78775-Update-error), `file_get_contents` will return `false` and subsequently the following error will be thrown:

```
Error: Uncaught TypeError: json_decode() expects parameter 1 to be string, boolean given in phar://…/web/contao-manager.phar.php/api/Process/AbstractProcess.php:60 Stack trace: 
#0 phar://…/web/contao-manager.phar.php/api/Process/AbstractProcess.php(60): json_decode(false, true) 
#1 phar://…/web/contao-manager.phar.php/api/Process/ProcessController.php(284): Contao\ManagerApi\Process\AbstractProcess::readConfig('…...') 
#2 phar://…/web/contao-manager.phar.php/api/Process/ProcessController.php(160): Contao\ManagerApi\Process\ProcessController->updateStatus() 
#3 phar://…/web/contao-manager.phar.php/api/Process/ProcessController.php(145): Contao\ManagerApi\Process\ProcessController->getStatus() 
#4 phar://…/web/contao-manager.phar.php/api/TaskOperation/AbstractProcessOperation.php(56): Contao\ManagerApi\Process\ProcessController->isStarted()
```

`is_readable` checks both whether the file exists and is readable. Though may be it should be two separate exceptions after all? Since, if the file exists, it's not really an invalid argument.