### PR TITLE
display error in packages

### DIFF
--- a/src/components/routes/Packages/Package.vue
+++ b/src/components/routes/Packages/Package.vue
@@ -261,6 +261,12 @@
                 time {
                     display: block;
                 }
+                
+                strong {
+                    @include screen(1024) {
+                        display: block;
+                    }
+                }
             }
 
             &--missing {


### PR DESCRIPTION
Fixes a display error with release versions that are too short

![image](https://user-images.githubusercontent.com/10244240/105163836-b17a7c00-5b14-11eb-8643-4e22e7280012.png)
