### PR TITLE
Skip .ddev config

### DIFF
--- a/api/Controller/Server/ContaoController.php
+++ b/api/Controller/Server/ContaoController.php
@@ -225,6 +225,7 @@ class ContaoController
                 '.env.local',
                 '.git',
                 '.idea',
+                '.ddev',
                 '.well-known',
                 'cgi-bin',
                 'contao-manager',


### PR DESCRIPTION
The .ddev directory is a config for ddev. Just skip it.
[https://ddev.readthedocs.io/en/stable/users/topics/whats_in_ddev_dir/](https://ddev.readthedocs.io/en/stable/users/topics/whats_in_ddev_dir/)