### PR TITLE
Fix could not proxy request error

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
     devServer: {
         proxy: {
             '/api': {
-                target: 'http://localhost:8000/',
+                target: 'http://127.0.0.1:8000/',
                 pathRewrite: { '^/api/': '/api.php/api/' },
             },
         },


### PR DESCRIPTION
Using the hostname localhost seems to have issues.
But I’m not sure if maybe something with my setup is wrong?

The error I get without this change:

```
Proxy error: Could not proxy request /api.php/api/session from localhost:8081 to http://localhost:8000/.
See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNREFUSED).
```