### PR TITLE
Fix vue warning

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = {
     productionSourceMap: false,
-    baseUrl: '',
+    publicPath: '',
 
     devServer: {
         proxy: {


### PR DESCRIPTION
Fixes the following warning:

```
WARN  "baseUrl" option in vue.config.js is deprecated now, please use "publicPath" instead.
```