### PR TITLE
Fix database URL pattern

### DIFF
--- a/api/Controller/Server/DatabaseController.php
+++ b/api/Controller/Server/DatabaseController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class DatabaseController
 {
-    private const URL_PATTERN = '^([^:]+)://(([^:@]+)(:([^@]+))?@)?([a-z][^:]+(:[0-9]+)?)/(.+)$';
+    private const URL_PATTERN = '^([^:]+)://(([^:@]+)(:([^@]+))?@)?([^:/]+(:[0-9]+)?)/(.+)$';
 
     public function __construct(ApiKernel $kernel, ContaoApi $contaoApi, ContaoConsole $contaoConsole, ConsoleProcessFactory $processFactory, LoggerInterface $logger = null, Filesystem $filesystem = null)
     {


### PR DESCRIPTION
Currently IP adresses weren’t allowed.
Like: `mysql://root:pwd@127.0.0.1:3306/db`