### PR TITLE
Export and use the PHP cli path from the cli binary itself

### DIFF
--- a/api/Process/PhpExecutableFinder.php
+++ b/api/Process/PhpExecutableFinder.php
@@ -189,6 +189,10 @@ class PhpExecutableFinder
                 continue;
             }
 
+            if (\array_key_exists('binary', $info)) {
+                $path = $info['binary'];
+            }
+
             if ('cli' === $info['sapi'] && version_compare(PHP_VERSION, $info['version'], 'eq')) {
                 return $path;
             }

--- a/api/console
+++ b/api/console
@@ -69,7 +69,11 @@ $input = new ArgvInput();
 switch ($input->getFirstArgument()) {
     // This "test" command is only for the dev version, if the Phar is compiled this is done in the stub.php
     case 'test':
-        die(json_encode(['version' => PHP_VERSION, 'version_id' => PHP_VERSION_ID, 'sapi' => PHP_SAPI]));
+        $reply = ['version' => PHP_VERSION, 'version_id' => PHP_VERSION_ID, 'sapi' => PHP_SAPI];
+        if (\defined('PHP_BINARY')) {
+            $reply['binary'] = PHP_BINARY;
+        }
+        die(json_encode($reply));
         break;
 
     case 'composer':

--- a/stub.php
+++ b/stub.php
@@ -34,7 +34,11 @@ if (function_exists('date_default_timezone_set') && function_exists('date_defaul
 
 if ('cli' === PHP_SAPI || !isset($_SERVER['REQUEST_URI'])) {
     if (isset($_SERVER['argv'][1]) && 'test' === $_SERVER['argv'][1]) {
-        die(json_encode(['version' => PHP_VERSION, 'version_id' => PHP_VERSION_ID, 'sapi' => PHP_SAPI]));
+        $reply = ['version' => PHP_VERSION, 'version_id' => PHP_VERSION_ID, 'sapi' => PHP_SAPI];
+        if (\defined('PHP_BINARY')) {
+            $reply['binary'] = PHP_BINARY;
+        }
+        die(json_encode($reply));
     }
 
     Phar::mapPhar('contao-manager.phar');


### PR DESCRIPTION
While searching the PHP cli path we use the first path which produces a valid result. However some hosters are re-writing exec paths, so the wrong (and possibly non-existent) path to the PHP cli ends in our configuration.

Instead of taking the path as-is we should rather use the path the PHP cli provides (PHP_BINARY).