### PR TITLE
use copy and unlink for Windows OS

### DIFF
--- a/api/System/SelfUpdate.php
+++ b/api/System/SelfUpdate.php
@@ -273,9 +273,9 @@ class SelfUpdate
      */
     private function install(string $tempFile, string $phar): void
     {
-        if ($this->isWindows()) {
+        if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->filesystem->copy($tempFile, $phar, true);
-            @unlink($tempFile);
+            $this->filesystem->remove($tempFile);
             return;
         }
 
@@ -296,13 +296,5 @@ class SelfUpdate
         }
 
         return [$filename, $extension];
-    }
-
-    /**
-     * Returns whether the host machine is running a Windows OS
-     */
-    private function isWindows(): bool
-    {
-        return \defined('PHP_WINDOWS_VERSION_BUILD');
     }
 }

--- a/api/System/SelfUpdate.php
+++ b/api/System/SelfUpdate.php
@@ -273,6 +273,12 @@ class SelfUpdate
      */
     private function install(string $tempFile, string $phar): void
     {
+        if ($this->isWindows()) {
+            $this->filesystem->copy($tempFile, $phar, true);
+            @unlink($tempFile);
+            return;
+        }
+
         $this->filesystem->rename($tempFile, $phar, true);
     }
 
@@ -290,5 +296,13 @@ class SelfUpdate
         }
 
         return [$filename, $extension];
+    }
+
+    /**
+     * Returns whether the host machine is running a Windows OS
+     */
+    private function isWindows(): bool
+    {
+        return \defined('PHP_WINDOWS_VERSION_BUILD');
     }
 }


### PR DESCRIPTION
During self-update on windows the manager can no longer rename the file.

![grafik](https://user-images.githubusercontent.com/10244240/196526318-7c2d9392-494c-4d9f-9d7f-d8cde8746f86.png)

I took a closer look, the problem is that the self-update wants to "update" the phar.php via rename. This does not work correctly under Windows. So I thought to myself, that can't be that it works for composer and not for the manager :wink: And look, composer had the problem too ... and switched to copy for Windows https://github.com/composer/composer/commit/07f59a91624611b3c91477d2a1e6f6a2ce45aa5e#diff-b94d538399979b0c8d2689da7[...]6df384993c58e2e924c640dea1R428

This PR will fix the issue for Windows.
Perhaps the downgrade process needs some attention as well, possibly other places
https://github.com/contao/contao-manager/blob/main/downgrade.php#L36
