### PR TITLE
Fix version constraint for contao-setup script change

### DIFF
--- a/api/Task/Packages/UpdateTask.php
+++ b/api/Task/Packages/UpdateTask.php
@@ -219,7 +219,7 @@ class UpdateTask extends AbstractPackagesTask
 
                 $versionParser = new VersionParser();
                 $constraint = $versionParser->parseConstraints($version);
-                $isContao5 = $constraint->matches(new Constraint('>', '4.13.9999'));
+                $isContao5 = $constraint->matches(new Constraint('>=', '5@dev'));
 
                 // Patch composer.json to make sure we have a valid public-dir and install scripts
                 if ($isContao5) {


### PR DESCRIPTION
Potential fix for #744. The reason why these people end up with `contao-setup` in their `composer.json` is likely because a version constraint of `>4.13.9999` also matches with `4.13.*` (e.g. `4.13.99991`) - but the intention was to only match Contao 5. This PR fixes that by changing the constraint to `>=5@dev`.