### PR TITLE
Update DatabaseConnection.vue

### DIFF
--- a/src/components/setup/DatabaseConnection.vue
+++ b/src/components/setup/DatabaseConnection.vue
@@ -4,7 +4,7 @@
             <img src="../../assets/images/database.svg" width="80" height="80" class="setup__icon" alt="">
             <h1 class="setup__headline">{{ $t('ui.setup.database-connection.headline') }}</h1>
             <i18n tag="p" path="ui.setup.database-connection.description" class="setup__description">
-                <template #env><code>.env</code></template>
+                <template #env><code>.env.local</code></template>
             </i18n>
         </header>
 


### PR DESCRIPTION
The `DATABASE_URL` environment variable is written to the `.env.local` file (at least in Contao 5.1). Should we annotate that in the database connection description, too?