### PR TITLE
Update the documentation shortlinks

### DIFF
--- a/src/components/setup/DocumentRoot.vue
+++ b/src/components/setup/DocumentRoot.vue
@@ -7,7 +7,7 @@
             <p class="setup__warning" v-if="needsFix">{{ $t('ui.setup.document-root.warning') }}</p>
             <p class="setup__description">{{ $t('ui.setup.document-root.description1') }}</p>
             <p class="setup__description">{{ $t('ui.setup.document-root.description2') }}</p>
-            <a class="widget-button widget-button--inline widget-button--info widget-button--link" href="https://to.contao.org/webroot" target="_blank">{{ $t('ui.setup.document-root.documentation') }}</a>
+            <a class="widget-button widget-button--inline widget-button--info widget-button--link" href="https://to.contao.org/docs/webroot" target="_blank">{{ $t('ui.setup.document-root.documentation') }}</a>
         </header>
 
         <transition :name="forceInstall ? 'none' : 'animate-flip'" type="transition" mode="out-in" v-if="projectDir !== null">

--- a/src/components/views/Account.vue
+++ b/src/components/views/Account.vue
@@ -10,7 +10,7 @@
                 <i18n :tag="false" path="ui.account.intro1">
                     <template #readTheManualToGetStarted>
                         <i18n tag="strong" path="ui.account.introGetStarted">
-                            <template #readTheManual><a href="https://docs.contao.org/manual/de/installation/contao-manager/" target="_blank">{{ $t('ui.account.introManual') }}</a></template>
+                            <template #readTheManual><a href="https://to.contao.org/docs/contao-manager" target="_blank">{{ $t('ui.account.introManual') }}</a></template>
                         </i18n>
                     </template>
                 </i18n>

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -17,7 +17,7 @@
                 <text-field ref="username" name="username" :label="$t('ui.login.username')" :placeholder="$t('ui.login.username')" :class="login_failed ? 'widget--error' : ''" :disabled="logging_in" v-model="username" @input="reset"/>
                 <text-field type="password" name="password" :label="$t('ui.login.password')" :placeholder="$t('ui.login.password')" :class="login_failed ? 'widget--error' : ''" :disabled="logging_in" v-model="password" @input="reset"/>
 
-                <a :href="`https://to.contao.org/manager-password?lang=${$i18n.locale}`" target="_blank" class="view-login__link">{{ $t('ui.login.forgotPassword') }}</a>
+                <a :href="`https://to.contao.org/docs/manager-password?lang=${$i18n.locale}`" target="_blank" class="view-login__link">{{ $t('ui.login.forgotPassword') }}</a>
 
                 <loading-button submit class="view-login__button" color="primary" :disabled="!inputValid || login_failed" :loading="logging_in">
                     {{ $t('ui.login.button') }}


### PR DESCRIPTION
The link in the `Login.vue` file has a `?lang=${$i18n.locale}` suffix, the links in the other files don‘t. Not sure if this needs to be added everywhere?