### PR TITLE
Show error message in migration view

### DIFF
--- a/api/Controller/Contao/DatabaseMigrationController.php
+++ b/api/Controller/Contao/DatabaseMigrationController.php
@@ -243,6 +243,7 @@ class DatabaseMigrationController
             $operations[$name] = [
                 'name' => $name,
                 'status' => !$process->isRunning() && !$process->isSuccessful() ? TaskStatus::STATUS_ERROR : 'pending',
+                'message' => '',
             ];
         }
 
@@ -258,6 +259,7 @@ class DatabaseMigrationController
 
             if ('schema-result' === $type) {
                 $operations[$name]['status'] = ($data['isSuccessful'] ? TaskStatus::STATUS_COMPLETE : TaskStatus::STATUS_ERROR);
+                $operations[$name]['message'] = $data['message'] ?? '';
             }
         }
 

--- a/api/Controller/Contao/DatabaseMigrationController.php
+++ b/api/Controller/Contao/DatabaseMigrationController.php
@@ -212,6 +212,7 @@ class DatabaseMigrationController
             $operations[] = [
                 'name' => $name,
                 'status' => 'pending',
+                'message' => '',
             ];
         }
 

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1604,8 +1604,7 @@ components:
                                     - error
                             message:
                                 type: string
-                                required: false
-                                description: Result message of an executed migration (not available for schema updates).
+                                description: Result message of an executed migration or error message for failed schema updates.
                 hash:
                     type: string
 

--- a/src/components/views/MigrationView.vue
+++ b/src/components/views/MigrationView.vue
@@ -307,6 +307,7 @@ export default {
                         operations.push({
                             status: change.status,
                             summary: this.$t('ui.migrate.addTable', { table: result[1] }),
+                            details: change.message,
                             console: change.name,
                         });
                         return;
@@ -317,6 +318,7 @@ export default {
                         operations.push({
                             status: this.withDeletes ? change.status : 'skipped',
                             summary: this.generateStatus(this.$t('ui.migrate.dropTable', { table: result[1] }), !this.withDeletes),
+                            details: change.message,
                             console: change.name,
                         });
                         this.hasDeletes = true;
@@ -328,7 +330,7 @@ export default {
                         operations.push({
                             status: change.status,
                             summary: this.$t('ui.migrate.createIndex', { name: result[1], table: result[2] }),
-                            details: result[3],
+                            details: result[3] + ' ' + change.message,
                             console: change.name,
                         });
                         return;
@@ -339,7 +341,7 @@ export default {
                         operations.push({
                             status: this.withDeletes ? change.status : 'skipped',
                             summary: this.generateStatus(this.$t('ui.migrate.dropIndex', { name: result[1], table: result[2] }), !this.withDeletes),
-                            details: result[3],
+                            details: change.message,
                             console: change.name,
                         });
                         this.hasDeletes = true;
@@ -355,6 +357,10 @@ export default {
                             details: [],
                             console: change.name,
                         };
+
+                        if (change.message) {
+                            operation.details.push(change.message);
+                        }
 
                         let stm = '';
                         result[2].split("'").forEach((ex, i) => {
@@ -407,6 +413,7 @@ export default {
                     operations.push({
                         status: change.status,
                         summary: change.name,
+                        details: change.message,
                         console: change.name,
                     });
 

--- a/src/components/views/MigrationView.vue
+++ b/src/components/views/MigrationView.vue
@@ -378,14 +378,18 @@ export default {
                             alter = new RegExp('^ADD ([^ ]+) (.+)$').exec(part);
                             if (alter) {
                                 operation.summary.push(this.$t('ui.migrate.addField', { table, field: alter[1] }));
-                                operation.details.push(alter[2]);
+                                if (!change.message) {
+                                    operation.details.push(alter[2]);
+                                }
                                 return;
                             }
 
                             alter = new RegExp('^CHANGE ([^ ]+) ([^ ]+) (.+)$').exec(part);
                             if (alter) {
                                 operation.summary.push(this.$t('ui.migrate.changeField', { table, field: alter[1] }));
-                                operation.details.push(alter[3]);
+                                if (!change.message) {
+                                    operation.details.push(alter[3]);
+                                }
                                 return;
                             }
 

--- a/src/components/views/MigrationView.vue
+++ b/src/components/views/MigrationView.vue
@@ -330,7 +330,7 @@ export default {
                         operations.push({
                             status: change.status,
                             summary: this.$t('ui.migrate.createIndex', { name: result[1], table: result[2] }),
-                            details: result[3] + ' ' + change.message,
+                            details: change.message || result[3],
                             console: change.name,
                         });
                         return;


### PR DESCRIPTION
Adds the error message to the migration view output as currently there is no way to know what went wrong when a schema migration fails.

![Bildschirmfoto 2024-04-15 um 18 17 04](https://github.com/contao/contao-manager/assets/367169/6d876500-e193-45fb-866f-4d69123c02c8)
