### PR TITLE
Align package details vertically centered

### DIFF
--- a/src/components/routes/Packages/BasePackage.vue
+++ b/src/components/routes/Packages/BasePackage.vue
@@ -354,9 +354,6 @@
             }
 
             &__details {
-                display: flex;
-                align-self: center;
-                align-items: center;
                 padding: $package-padding;
                 height: 100%;
                 min-height: 90px;
@@ -432,6 +429,11 @@
                 gap: 10px;
                 width: 180px;
                 margin-left: 20px;
+            }
+            &__details {
+                display: flex;
+                align-self: center;
+                align-items: center;
             }
         }
     }

--- a/src/components/routes/Packages/BasePackage.vue
+++ b/src/components/routes/Packages/BasePackage.vue
@@ -354,6 +354,9 @@
             }
 
             &__details {
+                display: flex;
+                align-self: center;
+                align-items: center;
                 padding: $package-padding;
                 height: 100%;
                 min-height: 90px;


### PR DESCRIPTION
This PR fixes the uneven top and bottom gaps for the .package__details element.


Before:
<img width="1283" alt="image" src="https://github.com/contao/contao-manager/assets/42083846/909414ad-e0ec-4e90-beae-01ca0e1bc7db">

After:
<img width="1260" alt="image" src="https://github.com/contao/contao-manager/assets/42083846/370a7e50-f931-4c27-9b60-d08dec80acbb">
