### PR TITLE
Add an AboutCommand return code

### DIFF
--- a/api/Command/AboutCommand.php
+++ b/api/Command/AboutCommand.php
@@ -49,11 +49,13 @@ class AboutCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $data = $this->collectData();
 
         $this->outputTable($input, $output, $data);
+
+        return Command::SUCCESS;
     }
 
     private function outputTable(InputInterface $input, OutputInterface $output, array $data): void

--- a/api/Command/IntegrityCheckCommand.php
+++ b/api/Command/IntegrityCheckCommand.php
@@ -64,12 +64,12 @@ class IntegrityCheckCommand extends Command
                 $output->writeln($detail);
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $output->writeln('<info>Running PHP '.PHP_VERSION.', all checks successful.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function writeJson(OutputInterface $output, ApiProblem $problem = null): int
@@ -85,6 +85,6 @@ class IntegrityCheckCommand extends Command
             )
         );
 
-        return $problem ? 1 : 0;
+        return $problem ? Command::FAILURE : Command::SUCCESS;
     }
 }

--- a/api/Command/ProcessRunnerCommand.php
+++ b/api/Command/ProcessRunnerCommand.php
@@ -42,9 +42,9 @@ class ProcessRunnerCommand extends Command
             $process->addOutput((string) $e);
             $process->stop();
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/api/Command/TaskAbortCommand.php
+++ b/api/Command/TaskAbortCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\ManagerApi\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -32,7 +33,7 @@ class TaskAbortCommand extends TaskUpdateCommand
         if (!$this->taskManager->hasTask()) {
             $output->writeln('No task is currently active.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $this->taskManager->abortTask();

--- a/api/Command/TaskDeleteCommand.php
+++ b/api/Command/TaskDeleteCommand.php
@@ -44,7 +44,7 @@ class TaskDeleteCommand extends Command
         if (!$this->taskManager->hasTask()) {
             $output->writeln('No task is currently active.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $status = $this->taskManager->deleteTask();
@@ -52,9 +52,9 @@ class TaskDeleteCommand extends Command
         if (null === $status || $status->isActive()) {
             $output->writeln('Task could not be deleted.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/api/Command/TaskUpdateCommand.php
+++ b/api/Command/TaskUpdateCommand.php
@@ -56,17 +56,17 @@ class TaskUpdateCommand extends Command
         if (!$this->taskManager->hasTask()) {
             $output->writeln('No task is currently active.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $status = $this->taskManager->updateTask();
 
         if (null === $status) {
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$output instanceof ConsoleOutput) {
-            return 1;
+            return Command::FAILURE;
         }
 
         $style = new SymfonyStyle($input, $output);
@@ -93,7 +93,7 @@ class TaskUpdateCommand extends Command
                 $newStatus = $this->taskManager->updateTask();
 
                 if (null === $newStatus) {
-                    return 1;
+                    return Command::FAILURE;
                 }
 
                 if ($this->updateOperations($newStatus->getOperations(), $sections, $progresses)) {
@@ -116,7 +116,7 @@ class TaskUpdateCommand extends Command
                 break;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/api/Command/UpdateCommand.php
+++ b/api/Command/UpdateCommand.php
@@ -73,6 +73,6 @@ class UpdateCommand extends Command
             );
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
### Description

* Fixes #817

* Also uses return Constants for better readability

### Return Constants

see:
https://tldp.org/LDP/abs/html/exitcodes.html
* `Command::SUCCESS = 0;`
* `Command::FAILURE = 1;`
* `Command::INVALID = 2;`

They exist in symfony/console 5.4 and still exist in 7.2

5.4:
https://github.com/symfony/console/blob/6473d441a913cb997123b59ff2dbe3d1cf9e11ba/Command/Command.php#L35-L38

7.2:
https://github.com/symfony/console/blob/b71a095124de660d598da3031c39e2790f64e28a/Command/Command.php#L37-L40
