### PR TITLE
Return a successful response if task already deleted

### DIFF
--- a/api/Controller/TaskController.php
+++ b/api/Controller/TaskController.php
@@ -93,7 +93,7 @@ class TaskController
     private function deleteTask(): Response
     {
         if (!$this->taskManager->hasTask()) {
-            throw new BadRequestHttpException('No active task found.');
+            return $this->getResponse();
         }
 
         try {


### PR DESCRIPTION
A `DELETE` request to a resource should be idempotent. Meaning that it should return the same response, no matter how many times I call it. 

Calling `DELETE` means I want to delete the current task. If it's already been deleted, that's okay too 😊 