### PR TITLE
Uncomment window.location.reload in ConfigView when updating config

### DIFF
--- a/src/components/views/ConfigView.vue
+++ b/src/components/views/ConfigView.vue
@@ -78,7 +78,7 @@ export default {
                         this.$refs.cli.focus();
                     }, 0)
                 } else {
-                    // window.location.reload(true);
+                    window.location.reload(true);
                 }
             },
 


### PR DESCRIPTION
Probably shouldn't be commented out. Without this it will get stuck like this:
![image](https://github.com/user-attachments/assets/b703a3c3-e3fc-4b63-81a0-b11f62727674)
