### PR TITLE
Fix exit safe mode link not working

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -5,7 +5,7 @@
         <div class="app-hint app-hint--alert" v-if="safeMode && view === 'ready'">
             <strong class="app-hint__headline">{{ $t('ui.app.safeModeHeadline') }}</strong>&nbsp;
             <span class="app-hint__description">{{ $t('ui.app.safeModeDescription') }}</span>&nbsp;
-            <button class="app-hint__link" @click="() => window.location.reload()">{{ $t('ui.app.safeModeExit') }}</button>
+            <button class="app-hint__link" @click="(e) => e.view.location.reload()">{{ $t('ui.app.safeModeExit') }}</button>
         </div>
 
         <div class="app-hint" v-if="limited">


### PR DESCRIPTION
window is not accessible in an event like that, this leads to the following error and the page wont reload.
<img width="581" alt="Screenshot 2025-02-20 at 09 06 13" src="https://github.com/user-attachments/assets/604a359e-d78d-490b-82e3-c1c00176001a" />

This can be fixed by using the view attribute of the event instead.