### PR TITLE
Fix layout shift on maintenance page

### DIFF
--- a/src/components/routes/MaintenanceRoute.vue
+++ b/src/components/routes/MaintenanceRoute.vue
@@ -74,6 +74,7 @@
     }
 
     &__image {
+        aspect-ratio: 1 / 1;
         display: none;
 
         img {

--- a/src/components/routes/MaintenanceRoute.vue
+++ b/src/components/routes/MaintenanceRoute.vue
@@ -74,7 +74,7 @@
     }
 
     &__image {
-        aspect-ratio: 1 / 1;
+        aspect-ratio: 1;
         display: none;
 
         img {


### PR DESCRIPTION
This PR fixes a layout shift on the maintenance page caused by the Symfony logo being taller than wide and thus causing the parent to grow vertically. This obviously causes all the content below to shift as soon as the image has loaded.
 
With this change the Symfony logo is displayed slightly smaller, but all rows have the same height and there is no layout shift.
Before:
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/a349fe68-0855-4a38-9a65-2d05ec629c6c" />
After:
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/bcac6504-99c5-4a25-bf3f-9690379b4990" />
