### PR TITLE
Move `aspect-ratio` to the img element

### DIFF
--- a/src/components/routes/MaintenanceRoute.vue
+++ b/src/components/routes/MaintenanceRoute.vue
@@ -76,14 +76,15 @@ export default {
 
         img {
             width: 100%;
-            height: 100%;
             border-radius: var(--border-radius);
             overflow: hidden;
             aspect-ratio: 1;
+            object-fit:contain;
         }
 
         @include defaults.screen(1024) {
-            display: block;
+            display: flex;
+            align-items: center;
         }
     }
 

--- a/src/components/routes/MaintenanceRoute.vue
+++ b/src/components/routes/MaintenanceRoute.vue
@@ -72,7 +72,6 @@ export default {
     }
 
     &__image {
-        aspect-ratio: 1;
         display: none;
 
         img {
@@ -80,6 +79,7 @@ export default {
             height: 100%;
             border-radius: var(--border-radius);
             overflow: hidden;
+            aspect-ratio: 1;
         }
 
         @include defaults.screen(1024) {


### PR DESCRIPTION
### Description

Safari said no to the introduced aspect-ratio in #865.

Moving it to the `img` element should fix the following behavior:
![image](https://github.com/user-attachments/assets/b075f225-12c3-4abe-85a0-896666eb830f)
