### PR TITLE
Correctly toggle `context` and `extra` in the LogViewer

### DIFF
--- a/src/components/routes/LogViewerRoute.vue
+++ b/src/components/routes/LogViewerRoute.vue
@@ -196,11 +196,11 @@ export default {
         },
 
         toggleContext(k) {
-            this.$set(this.showContext, k, !this.showContext[k]);
+            this.showContext[k] ^= 1;
         },
 
         toggleExtra(k) {
-            this.$set(this.showExtra, k, !this.showExtra[k]);
+            this.showExtra[k] ^= 1;
         },
 
         countOptions(key, options = {}) {

--- a/src/components/routes/LogViewerRoute.vue
+++ b/src/components/routes/LogViewerRoute.vue
@@ -196,11 +196,11 @@ export default {
         },
 
         toggleContext(k) {
-            this.showContext[k] ^= 1;
+            this.showContext[k] = !this.showContext[k];
         },
 
         toggleExtra(k) {
-            this.showExtra[k] ^= 1;
+            this.showExtra[k] = !this.showExtra[k];
         },
 
         countOptions(key, options = {}) {


### PR DESCRIPTION
### Description

* fixes #871 

`$set` has been removed in Vue3 - we can set it properly now.

*Additional information*
- `^= 1` is a bitwise XOR so it assigns the negated state :) (m-vo taught me :D)