### PR TITLE
Allow force installing incompatible packages

### DIFF
--- a/src/assets/styles/_app.scss
+++ b/src/assets/styles/_app.scss
@@ -1,0 +1,2 @@
+@use "defaults" as *;
+@use "forms" as *;

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -1,0 +1,12 @@
+.widget-button {
+
+  &--incompatible {
+    background-color: var(--btn-disabled);
+    border-color: var(--btn-disabled);
+    opacity: var(--opacity-disabled, 1);
+
+    &:hover {
+      background-color: var(--btn-warning);
+    }
+  }
+}

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -212,7 +212,7 @@ export default {
 @use "~contao-package-list/src/assets/styles/forms";
 @use "~contao-package-list/src/assets/styles/animations";
 @use "~contao-package-list/src/assets/styles/defaults";
-@use "../assets/styles/defaults" as AppDefaults;
+@use "../assets/styles/app" as AppDefaults;
 
 @import '~notivue/notifications.css';
 @import '~notivue/animations.css';

--- a/src/components/fragments/InstallButton.vue
+++ b/src/components/fragments/InstallButton.vue
@@ -4,8 +4,9 @@
         icon="add"
         :small="small"
         :inline="inline"
+        :compatible="isCompatible"
         :disabled="disabled || isRootInstalled || isAdded || isRequired || !canBeInstalled"
-        @click="install"
+        @click="install(isCompatible)"
         v-if="isGranted(scopes.INSTALL)"
     >
         {{ $t(small ? 'ui.package.installButtonShort' : 'ui.package.installButton') }}

--- a/src/components/widgets/ConfirmButton.vue
+++ b/src/components/widgets/ConfirmButton.vue
@@ -21,6 +21,7 @@ export default {
         icon: String,
         inline: Boolean,
         small: Boolean,
+        compatible: Boolean,
         disabled: Boolean,
     },
 
@@ -34,6 +35,7 @@ export default {
             'widget-button': true,
             'widget-button--inline': vm.inline,
             'widget-button--small': vm.small,
+            'widget-button--incompatible': !vm.compatible,
             [`widget-button--${vm.color}`]: vm.color,
         }),
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -469,6 +469,7 @@
     "ui.package.updateUnknown": "unknown version",
     "ui.package.updateConstraint": "A newer version outside your version constraint is available.",
     "ui.package.incompatible": "{package} does not work with Contao {constraint}.",
+    "ui.package.forceInstall": "{package} does not work with your Contao version. Are you sure you want to add this package?",
 
     "ui.cloudStatus.headline": "Composer Resolver Cloud",
     "ui.cloudStatus.version": "Version {version}",

--- a/src/mixins/packageStatus.js
+++ b/src/mixins/packageStatus.js
@@ -60,7 +60,7 @@ export default {
         installedTime: (vm) => (vm.installed[vm.data.name] ? vm.installed[vm.data.name].time : null),
 
         isCompatible: (vm) => vm.contaoSupported(vm.metadata.contaoConstraint),
-        canBeInstalled: (vm) => (!vm.isPrivate || vm.isSuggested) && !vm.isTheme && (!vm.isDependency || vm.isSuggested) && vm.isCompatible,
+        canBeInstalled: (vm) => (!vm.isPrivate || vm.isSuggested) && !vm.isTheme && (!vm.isDependency || vm.isSuggested),
 
         constraintInstalled: (vm) => vm.packageConstraintInstalled(vm.data.name),
         constraintRequired: (vm) => vm.packageConstraintRequired(vm.data.name),
@@ -71,7 +71,10 @@ export default {
     },
 
     methods: {
-        install() {
+        install(compatible = true) {
+            if (!compatible && !confirm(this.$t('ui.package.forceInstall', { package: this.data.name }))) {
+                return;
+            }
             this.$store.commit('packages/add', this.metadata || this.data);
         },
 


### PR DESCRIPTION
### Description

* kinda implements #867 or rather removes the hardcoded `disabled` for packages

This PR changes the `Add`-Button to allow incompatible (due to the contao version constraint) packages to be installed again but prompts the user with a `confirm` dialog to add the package.

<img width="511" height="176" alt="image" src="https://github.com/user-attachments/assets/52d2e500-9b24-4484-8890-b2ec2d1c5da8" />
<img width="1288" height="492" alt="image" src="https://github.com/user-attachments/assets/6c0e1d73-6d6b-48f1-84dd-5f2ccfa720d4" />
