### PR TITLE
Include prerelease versions in Contao constraint check

### DIFF
--- a/src/store/packages.js
+++ b/src/store/packages.js
@@ -115,7 +115,7 @@ export default {
         },
         contaoConstraint: (s, g) =>
             g.packageConstraint('contao/manager-bundle') ? coerce(g.packageConstraint('contao/manager-bundle'), { includePrerelease: true }).toString() : '',
-        contaoSupported: (s, g) => (constraint) => (constraint ? intersects(constraint, g.contaoConstraint, true) : true),
+        contaoSupported: (s, g) => (constraint) => (constraint ? intersects(constraint, g.contaoConstraint, { includePrerelease: true, loose: true }) : true),
     },
 
     mutations: {


### PR DESCRIPTION
Currently, if you have a pre-release version of Contao such as 5.6.0-RC2 installed, all extensions will be marked as incompatible because pre-release versions are ignored by semver.intersects by default.
This PR adds the includePrerelease option to the check, thereby fixing the problem.


<img width="980" height="140" alt="image" src="https://github.com/user-attachments/assets/60abcc5c-2a03-489b-8475-3ceb314c4dfa" />

<br/><br/>

**Before** 

<img width="1304" height="1101" alt="image" src="https://github.com/user-attachments/assets/0a533a66-b216-45c4-9d22-c81d5234ff70" />

<br/><br/>

**After** 
 
<img width="1220" height="1070" alt="image" src="https://github.com/user-attachments/assets/d2bffcaa-1f42-44eb-bea4-9c3cdea37946" />
