### PR TITLE
Don't run `composer install --dry-run` after `composer update --dry-run`

### DIFF
--- a/api/Task/Packages/UpdateTask.php
+++ b/api/Task/Packages/UpdateTask.php
@@ -96,7 +96,7 @@ class UpdateTask extends AbstractPackagesTask
             $operations[] = new MaintenanceModeOperation($config, $this->processFactory, 'enable');
         }
 
-        if (!$changes->getDryRun()) {
+        if (!$changes->getDryRun() || $this->environment->useCloudResolver()) {
             $operations[] = new InstallOperation($this->processFactory, $config, $this->environment, $this->translator, false, !$config->isCancelled());
         }
 


### PR DESCRIPTION
Running `composer install --dry-run` after `composer update --dry-run` will always cause the install to fail, at least when dry-running an installation of a new package, because `composer install` expects the package to be in the `composer.lock`, which it obviously isn't after a `composer update --dry-run`.
IMO the `composer install --dry-run` can be completely removed, as, even if this problem wouldn't exist, the important part when dry-running a change is resolving the packages to an installable set, so `composer update`, and the post-install, which of course cannot be dry-ran anyway. So the `composer install --dry-run` is kinda useless.

Example of an error in `composer install` when dry-running (installed package doesn't matter, happens with every package)
```
$ /usr/bin/php8.5 -q -dmax_execution_time=0 -dmemory_limit=-1 -ddisplay_errors=0 -ddisplay_startup_errors=0 -derror_reporting=0 -dallow_url_fopen=1 -ddisable_functions= -ddate.timezone=Europe/Berlin /var/customers/webs/-/public/contao-manager.phar.php composer install --no-dev --no-progress --no-ansi --no-interaction --optimize-autoloader --dry-run --no-scripts --no-plugins
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
- Required package "-/-" is not present in the lock file.
This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
Read more about correctly resolving merge conflicts https://getcomposer.org/doc/articles/resolving-merge-conflicts.md
and prefer using the "require" command over editing the composer.json file directly https://getcomposer.org/doc/03-cli.md#require-r
# Process terminated with exit code 4
# Result: Unknown error
```