### PR TITLE
Windows compatibility for building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "@vue/cli-plugin-eslint": "~5.0.8",
                 "@vue/cli-service": "~5.0.8",
                 "@vue/compiler-sfc": "^3.5.13",
+                "cross-env": "^10.1.0",
                 "cypress": "^13.6.4",
                 "eslint": "^7.32.0",
                 "eslint-plugin-vue": "^8.0.3",
@@ -2013,6 +2014,13 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@eslint/eslintrc": {
             "version": "0.4.3",
@@ -6236,6 +6244,24 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+            "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
+            },
+            "bin": {
+                "cross-env": "dist/bin/cross-env.js",
+                "cross-env-shell": "dist/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "private": true,
     "homepage": "https://github.com/contao/contao-manager",
     "scripts": {
-        "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
-        "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
-        "build-dev": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --mode development",
+        "serve": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+        "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
+        "build-dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --mode development",
         "lint": "vue-cli-service lint",
         "cs-fixer": "prettier --write src"
     },
@@ -41,6 +41,7 @@
         "@vue/cli-plugin-eslint": "~5.0.8",
         "@vue/cli-service": "~5.0.8",
         "@vue/compiler-sfc": "^3.5.13",
+        "cross-env": "^10.1.0",
         "cypress": "^13.6.4",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^8.0.3",


### PR DESCRIPTION
This adds Windows compatibility for running `composer run phing …` via [`cross-env`](https://github.com/kentcdodds/cross-env),