### PR TITLE
Add '--no-dev' option to composer dump-autoload

### DIFF
--- a/api/TaskOperation/Composer/DumpAutoloadOperation.php
+++ b/api/TaskOperation/Composer/DumpAutoloadOperation.php
@@ -32,6 +32,7 @@ class DumpAutoloadOperation extends AbstractProcessOperation
                     [
                         'composer',
                         'dump-autoload',
+                        '--no-dev',
                         '--optimize',
                     ],
                     'dump-autoload',


### PR DESCRIPTION
We already do that correctly for [the install task](https://github.com/contao/contao-manager/blob/1ccc7c71f4919385aab3de233f623b69e3ac816b/api/TaskOperation/Composer/InstallOperation.php#L49) etc. but when dumping the autoload file from the maintenance screen, the `--no-dev` is missing.